### PR TITLE
Small fixes

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -1,3 +1,5 @@
+import org.apache.tools.ant.filters.ReplaceTokens
+
 plugins {
     id 'com.github.johnrengelman.shadow' version '7.1.2'
     id 'java-library'
@@ -28,7 +30,7 @@ shadowJar {
 processResources {
     inputs.property("version", project.version)
 
-    filter org.apache.tools.ant.filters.ReplaceTokens, tokens: [
+    filter ReplaceTokens, tokens: [
             'VERSION': project.version
     ]
 }

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -1,8 +1,8 @@
 import org.apache.tools.ant.filters.ReplaceTokens
 
 plugins {
-    id 'com.github.johnrengelman.shadow' version '7.1.2'
     id 'java-library'
+    id 'io.github.goooler.shadow' version '8.1.7'
 }
 
 version = "7.2.1"


### PR DESCRIPTION
Fix warning for “processResources”.
Replacing Shadow with a fork that is updated and supports the latest versions of Java/Gradle.